### PR TITLE
Add support for Annotation-based Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ You can also use annotation-based configs:
 public class ExampleAnnotationConfig {
 
     @Entry
+    @Validate.StringNotEmpty
     public String myString = "Default String"; // Default values should not be null
 
-    @Entry
+    @Entry("some.other.path")
     @Description("Enter description here") // May be ignored if the implementation does not support comments
     public int myInt = 5;
 
@@ -89,10 +90,12 @@ public class ExampleAnnotationConfig {
 }
 ```
 ```java
+AnnotationConfigManager annotationConfigManager = AnnotationConfigManager.create(); // Create an AnnotationConfigManager. The instance can be reused.
+
 Config yamlConfig = YamlConfig.of(file); // Create a config
 
 // Register our annotated class
-ExampleAnnotationConfig config = AnnotationConfigManager.register(yamlConfig, ExampleAnnotationConfig.class);
+ExampleAnnotationConfig config = annotationConfigManager.init(yamlConfig, ExampleAnnotationConfig.class);
 
 yamlConfig.load(); // Load the config from storage
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,38 @@ JASKL can automatically validate config entries (e.g. ensure that a number is al
 IntegerConfigEntry positiveIntegerConfigEntry = IntegerConfigEntry.of(config, "example.integer", "Example Integer", 1, Validator.INTEGER_POSITIVE);
 ```
 
+### Annotation-based Configs
+You can also use annotation-based configs:
+```java
+public class ExampleAnnotationConfig {
+
+    @Entry
+    public String myString = "Default String"; // Default values should not be null
+
+    @Entry
+    @Description("Enter description here") // May be ignored if the implementation does not support comments
+    public int myInt = 5;
+
+    public ExampleAnnotationConfig() {} // An empty constructor is required
+}
+```
+```java
+Config yamlConfig = YamlConfig.of(file); // Create a config
+
+// Register our annotated class
+ExampleAnnotationConfig config = AnnotationConfigManager.register(yamlConfig, ExampleAnnotationConfig.class);
+
+yamlConfig.load(); // Load the config from storage
+
+System.out.println(config.myString); // Print some value we just loaded
+
+config.myString = "Hello World"; // Change the value
+
+// Write the config to storage
+// This also checks/validates changed values
+yamlConfig.write();
+```
+
 ### Building
 To build the project, open the terminal and type `./gradlew build`. All jars will be located at `/<implementation>/build/libs/<implementation>-<version>.jar`.
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/Config.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/Config.java
@@ -31,8 +31,10 @@ public interface Config {
      *
      * @throws IOException if an I/O exception occurs.
      * @throws IllegalStateException if called multiple times.
+     * @throws InvalidTypeException if a value does not match its expected {@link Type}
+     * @throws ValidationException if a value fails validation
      */
-    void load() throws IOException, IllegalStateException;
+    void load() throws IOException, IllegalStateException, InvalidTypeException, ValidationException;
 
     /**
      * Reloads the config.
@@ -41,15 +43,19 @@ public interface Config {
      *
      * @throws IOException if an I/O exception occurs.
      * @throws IllegalStateException if {@link Config#load()} hasn't been called.
+     * @throws InvalidTypeException if a value does not match its expected {@link Type}
+     * @throws ValidationException if a value fails validation
      */
-    void reload() throws IOException, IllegalStateException;
+    void reload() throws IOException, IllegalStateException, InvalidTypeException, ValidationException;;
 
     /**
      * Saves the configuration to it's corresponding data storage location.
      *
      * @throws IOException if an I/O exception occurs.
+     * @throws InvalidTypeException if a value does not match its expected {@link Type}
+     * @throws ValidationException if a value fails validation
      */
-    void write() throws IOException;
+    void write() throws IOException, InvalidTypeException, ValidationException;;
 
     /**
      * Cleans up dead entries from the storage location.

--- a/core/src/main/java/io/github/almightysatan/jaskl/ConfigEntry.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/ConfigEntry.java
@@ -43,8 +43,10 @@ public interface ConfigEntry<T> {
      * Returns the value of this ConfigEntry.
      *
      * @return the value of this ConfigEntry
+     * @throws InvalidTypeException if the value does not match its expected {@link Type}
+     * @throws ValidationException  if the value fails validation
      */
-    @NotNull T getValue();
+    @NotNull T getValue() throws InvalidTypeException, ValidationException;
 
     /**
      * Returns the value of this ConfigEntry.
@@ -57,6 +59,8 @@ public interface ConfigEntry<T> {
      * Updates the value of this ConfigEntry.
      *
      * @param value The new value
+     * @throws InvalidTypeException if the given value does not match its expected {@link Type}
+     * @throws ValidationException  if the given value fails validation
      */
     void setValue(@NotNull T value) throws InvalidTypeException, ValidationException;
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/InvalidTypeException.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/InvalidTypeException.java
@@ -39,4 +39,8 @@ public class InvalidTypeException extends RuntimeException {
     public InvalidTypeException(@NotNull String path, @NotNull InvalidTypeException cause) {
         super(String.format("Invalid type: path=%s", path), cause);
     }
+
+    public InvalidTypeException(@NotNull String path) {
+        super(String.format("Invalid type: path=%s is null", path));
+    }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/Type.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/Type.java
@@ -280,7 +280,9 @@ public interface Type<T> {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    static @Nullable Type<?> of(Class<?> type) {
+    static @Nullable Type<?> of(@Nullable Class<?> type) {
+        if (type == null)
+            return null;
         if (type == boolean.class || type == Boolean.class)
             return Type.BOOLEAN;
         if (type == double.class || type == Double.class)
@@ -296,5 +298,44 @@ public interface Type<T> {
         if (type.isEnum())
             return Type.enumType((Class<? extends Enum>) type);
         return null;
+    }
+
+    static @Nullable Type<?> of(@Nullable Iterator<Class<?>> types) {
+        if (types == null || !types.hasNext())
+            return null;
+
+        Class<?> typeClass = types.next();
+        if (typeClass == null)
+            return null;
+
+        if (List.class.isAssignableFrom(typeClass)) {
+            Type<?> type = of(types);
+            if (type == null)
+                return null;
+            return Type.list(type);
+        }
+        if (Map.class.isAssignableFrom(typeClass)) {
+            Type<?> keyType = of(types);
+            Type<?> valueType = of(types);
+            if (keyType == null)
+                return null;
+            if (valueType == null)
+                return null;
+            return Type.map(keyType, valueType);
+        }
+
+        return of(typeClass);
+    }
+
+    static @Nullable Type<?> of(@Nullable List<Class<?>> types) {
+        if (types == null)
+            return null;
+        return of(types.iterator());
+    }
+
+    static @Nullable Type<?> of(@Nullable Class<?>[] types) {
+        if (types == null)
+            return null;
+        return of(Arrays.asList(types));
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/Type.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/Type.java
@@ -22,6 +22,7 @@ package io.github.almightysatan.jaskl;
 
 import io.github.almightysatan.jaskl.impl.SimpleType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -270,5 +271,24 @@ public interface Type<T> {
                 return Collections.unmodifiableMap(newMap);
             }
         };
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    static @Nullable Type<?> of(Class<?> type) {
+        if (type == boolean.class || type == Boolean.class)
+            return Type.BOOLEAN;
+        if (type == double.class || type == Double.class)
+            return Type.DOUBLE;
+        if (type == float.class || type == Float.class)
+            return Type.FLOAT;
+        if (type == int.class || type == Integer.class)
+            return Type.INTEGER;
+        if (type == long.class || type == Long.class)
+            return Type.LONG;
+        if (type == String.class)
+            return Type.STRING;
+        if (type.isEnum())
+            return Type.enumType((Class<? extends Enum>) type);
+        return null;
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/Type.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/Type.java
@@ -43,7 +43,13 @@ public interface Type<T> {
             @Override
             public @NotNull T toEntryType(@NotNull Object value) throws InvalidTypeException, ValidationException {
                 T casted = type.toEntryType(value);
-                validator.validate(casted);
+                try {
+                    validator.validate(casted);
+                } catch (ValidationException e) {
+                    throw e;
+                } catch (Throwable t) {
+                    throw new ValidationException("Exception while validating", t);
+                }
                 return casted;
             }
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/ValidationException.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/ValidationException.java
@@ -34,15 +34,19 @@ public class ValidationException extends RuntimeException {
     private final String errorMessage;
 
     public ValidationException(@NotNull String errorMessage) {
-        super(String.format("Config error: unknown entry %s", Objects.requireNonNull(errorMessage)));
+        this(errorMessage, (Throwable) null);
+    }
+
+    public ValidationException(@NotNull String errorMessage, @Nullable Throwable cause) {
+        super(String.format("Config error: unknown entry %s", Objects.requireNonNull(errorMessage)), cause);
         this.path = null;
         this.errorMessage = errorMessage;
     }
 
-    public ValidationException(@NotNull String path, @NotNull String errorMessage) {
-        super(String.format("Config error: %s %s", Objects.requireNonNull(path), Objects.requireNonNull(errorMessage)));
+    public ValidationException(@NotNull String path, @NotNull ValidationException exception) {
+        super(String.format("Config error: %s %s", Objects.requireNonNull(path), Objects.requireNonNull(exception.errorMessage)), exception.getCause());
         this.path = path;
-        this.errorMessage = errorMessage;
+        this.errorMessage = exception.errorMessage;
     }
 
     /**

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -27,6 +27,7 @@ import io.github.almightysatan.jaskl.Validator;
 import io.github.almightysatan.jaskl.impl.AnnotationConfigManagerImpl;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 public interface AnnotationConfigManager {
@@ -34,6 +35,7 @@ public interface AnnotationConfigManager {
     <T> void registerValidatorFunction(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction);
 
     default void registerValidator(@NotNull Class<?> annotationClass, @NotNull Validator<?> validator) {
+        Objects.requireNonNull(validator);
         this.registerValidatorFunction(annotationClass, annotation -> validator);
     }
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -1,0 +1,132 @@
+/*
+ * JASKL - Just Another Simple Konfig Library
+ * Copyright (C) 2023 UeberallGebannt, Almighty-Satan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.github.almightysatan.jaskl.annotation;
+
+import io.github.almightysatan.jaskl.Config;
+import io.github.almightysatan.jaskl.InvalidTypeException;
+import io.github.almightysatan.jaskl.Type;
+import io.github.almightysatan.jaskl.ValidationException;
+import io.github.almightysatan.jaskl.impl.WritableConfigEntry;
+import io.github.almightysatan.jaskl.impl.WritableConfigEntryImpl;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class AnnotationConfigManager {
+
+    public static <T> T register(Config config, Class<T> configClass) throws InvalidAnnotationConfigException {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(configClass);
+        try {
+            T instance = configClass.newInstance();
+
+            for (Field field : configClass.getFields()) {
+                if (Modifier.isFinal(field.getModifiers()))
+                    throw new InvalidAnnotationConfigException(String.format("Field %s is final", field.getName()));
+
+                Entry annotation = field.getAnnotation(Entry.class);
+                if (annotation != null) {
+                    String path = annotation.value().isEmpty() ? field.getName() : annotation.value();
+                    Object defaultValue = field.get(instance);
+                    if (defaultValue == null)
+                        throw new InvalidAnnotationConfigException(String.format("Default value of field %s is null", field.getName()));
+
+                    @SuppressWarnings("unchecked")
+                    Type<Object> type = (Type<Object>) Type.of(field.getType());
+                    if (type == null)
+                        throw new InvalidAnnotationConfigException(String.format("Unknown type for field %s", field.getName()));
+
+                    Description descriptionAnnotation = field.getAnnotation(Description.class);
+                    String description = descriptionAnnotation != null ? descriptionAnnotation.value() : null;
+
+                    WritableConfigEntry<?> entry = new WritableAnnotationConfigEntry<>(type, path, description, defaultValue, field, instance);
+                    entry.register(config);
+                }
+            }
+
+            return instance;
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new InvalidAnnotationConfigException(e);
+        }
+    }
+
+    private static class WritableAnnotationConfigEntry<T> extends WritableConfigEntryImpl<T> {
+
+        private final Field field;
+        private final Object instance;
+        private Object prevFieldValue;
+
+        public WritableAnnotationConfigEntry(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue, @NotNull Field field, @NotNull Object instance) {
+            super(type, path, description, defaultValue);
+            this.field = field;
+            this.instance = instance;
+            this.prevFieldValue = defaultValue;
+        }
+
+        @Override
+        public @NotNull T getValue() {
+            this.checkField();
+            return super.getValue();
+        }
+
+        @Override
+        public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
+            this.checkField();
+            return super.getValueToWrite(keyPreprocessor);
+        }
+
+        @Override
+        public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
+            this.setField(value);
+            super.setValue(value);
+        }
+
+        @Override
+        public void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException {
+            this.setField(value);
+            super.putValue(value);
+        }
+
+        private void checkField() {
+            try {
+                @SuppressWarnings("unchecked")
+                T fieldValue = (T) this.field.get(this.instance);
+                if (this.prevFieldValue != fieldValue)
+                    this.setValue(fieldValue);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private void setField(@NotNull Object value) {
+            try {
+                this.field.set(this.instance, value);
+                this.prevFieldValue = value;
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -31,12 +31,11 @@ import java.util.function.Function;
 
 public interface AnnotationConfigManager {
 
-    // TODO rename me
-    <T> void register(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction);
+    // rename this maybe???
+    <T> void registerValidatorFunction(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction);
 
-    // TODO rename me
-    default void register0(@NotNull Class<?> annotationClass, @NotNull Validator<?> validator) {
-        this.register(annotationClass, annotation -> validator);
+    default void registerValidator(@NotNull Class<?> annotationClass, @NotNull Validator<?> validator) {
+        this.registerValidatorFunction(annotationClass, annotation -> validator);
     }
 
     /**

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -39,8 +39,24 @@ public interface AnnotationConfigManager {
         this.register(annotationClass, annotation -> validator);
     }
 
+    /**
+     * Registers config entries for the given annotated class.
+     *
+     * @param config a config instance
+     * @param configClass a class containing annotated fields
+     * @return an instance of the given class
+     * @param <T> the type of the class
+     * @throws InvalidAnnotationConfigException if the config class is misconfigured
+     * @throws InvalidTypeException if a default value fails type checking
+     * @throws ValidationException if a default value fails validation
+     */
     <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException, InvalidTypeException, ValidationException;
 
+    /**
+     * Creates a new {@link AnnotationConfigManager}.
+     *
+     * @return a new instance
+     */
     static @NotNull AnnotationConfigManager create() {
         return new AnnotationConfigManagerImpl();
     }

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -21,112 +21,25 @@
 package io.github.almightysatan.jaskl.annotation;
 
 import io.github.almightysatan.jaskl.Config;
-import io.github.almightysatan.jaskl.InvalidTypeException;
-import io.github.almightysatan.jaskl.Type;
-import io.github.almightysatan.jaskl.ValidationException;
-import io.github.almightysatan.jaskl.impl.WritableConfigEntry;
-import io.github.almightysatan.jaskl.impl.WritableConfigEntryImpl;
+import io.github.almightysatan.jaskl.Validator;
+import io.github.almightysatan.jaskl.impl.AnnotationConfigManagerImpl;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Objects;
 import java.util.function.Function;
 
-public class AnnotationConfigManager {
+public interface AnnotationConfigManager {
 
-    public static <T> T register(Config config, Class<T> configClass) throws InvalidAnnotationConfigException {
-        Objects.requireNonNull(config);
-        Objects.requireNonNull(configClass);
-        try {
-            T instance = configClass.newInstance();
+    // TODO rename me
+    <T> void register(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction);
 
-            for (Field field : configClass.getFields()) {
-                if (Modifier.isFinal(field.getModifiers()))
-                    throw new InvalidAnnotationConfigException(String.format("Field %s is final", field.getName()));
-
-                Entry annotation = field.getAnnotation(Entry.class);
-                if (annotation != null) {
-                    String path = annotation.value().isEmpty() ? field.getName() : annotation.value();
-                    Object defaultValue = field.get(instance);
-                    if (defaultValue == null)
-                        throw new InvalidAnnotationConfigException(String.format("Default value of field %s is null", field.getName()));
-
-                    @SuppressWarnings("unchecked")
-                    Type<Object> type = (Type<Object>) Type.of(field.getType());
-                    if (type == null)
-                        throw new InvalidAnnotationConfigException(String.format("Unknown type for field %s", field.getName()));
-
-                    Description descriptionAnnotation = field.getAnnotation(Description.class);
-                    String description = descriptionAnnotation != null ? descriptionAnnotation.value() : null;
-
-                    WritableConfigEntry<?> entry = new WritableAnnotationConfigEntry<>(type, path, description, defaultValue, field, instance);
-                    entry.register(config);
-                }
-            }
-
-            return instance;
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new InvalidAnnotationConfigException(e);
-        }
+    // TODO rename me
+    default void register0(@NotNull Class<?> annotationClass, @NotNull Validator<?> validator) {
+        this.register(annotationClass, annotation -> validator);
     }
 
-    private static class WritableAnnotationConfigEntry<T> extends WritableConfigEntryImpl<T> {
+    <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException;
 
-        private final Field field;
-        private final Object instance;
-        private Object prevFieldValue;
-
-        public WritableAnnotationConfigEntry(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue, @NotNull Field field, @NotNull Object instance) {
-            super(type, path, description, defaultValue);
-            this.field = field;
-            this.instance = instance;
-            this.prevFieldValue = defaultValue;
-        }
-
-        @Override
-        public @NotNull T getValue() {
-            this.checkField();
-            return super.getValue();
-        }
-
-        @Override
-        public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
-            this.checkField();
-            return super.getValueToWrite(keyPreprocessor);
-        }
-
-        @Override
-        public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
-            this.setField(value);
-            super.setValue(value);
-        }
-
-        @Override
-        public void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException {
-            this.setField(value);
-            super.putValue(value);
-        }
-
-        private void checkField() {
-            try {
-                @SuppressWarnings("unchecked")
-                T fieldValue = (T) this.field.get(this.instance);
-                if (this.prevFieldValue != fieldValue)
-                    this.setValue(fieldValue);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        private void setField(@NotNull Object value) {
-            try {
-                this.field.set(this.instance, value);
-                this.prevFieldValue = value;
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        }
+    static @NotNull AnnotationConfigManager create() {
+        return new AnnotationConfigManagerImpl();
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -31,7 +31,6 @@ import java.util.function.Function;
 
 public interface AnnotationConfigManager {
 
-    // rename this maybe???
     <T> void registerValidatorFunction(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction);
 
     default void registerValidator(@NotNull Class<?> annotationClass, @NotNull Validator<?> validator) {

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/AnnotationConfigManager.java
@@ -21,6 +21,8 @@
 package io.github.almightysatan.jaskl.annotation;
 
 import io.github.almightysatan.jaskl.Config;
+import io.github.almightysatan.jaskl.InvalidTypeException;
+import io.github.almightysatan.jaskl.ValidationException;
 import io.github.almightysatan.jaskl.Validator;
 import io.github.almightysatan.jaskl.impl.AnnotationConfigManagerImpl;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +39,7 @@ public interface AnnotationConfigManager {
         this.register(annotationClass, annotation -> validator);
     }
 
-    <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException;
+    <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException, InvalidTypeException, ValidationException;
 
     static @NotNull AnnotationConfigManager create() {
         return new AnnotationConfigManagerImpl();

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/Description.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/Description.java
@@ -18,31 +18,18 @@
  * USA
  */
 
-package io.github.almightysatan.jaskl.impl;
+package io.github.almightysatan.jaskl.annotation;
 
-import io.github.almightysatan.jaskl.*;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-import java.util.function.Function;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface WritableConfigEntry<T> extends ConfigEntry<T> {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Description {
 
-    Type<T> getType();
-
-    void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException;
-
-    @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException;
-
-    default @NotNull Object getValueToWrite() throws InvalidTypeException, ValidationException {
-        return this.getValueToWrite(Function.identity());
-    }
-
-    boolean isModified();
-
-    default WritableConfigEntry<T> register(@NotNull Config config) {
-        Objects.requireNonNull(config);
-        ((ConfigImpl) config).registerEntry(this);
-        return this;
-    }
+    @NotNull String value();
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/Entry.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/Entry.java
@@ -18,31 +18,18 @@
  * USA
  */
 
-package io.github.almightysatan.jaskl.impl;
+package io.github.almightysatan.jaskl.annotation;
 
-import io.github.almightysatan.jaskl.*;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
-import java.util.function.Function;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public interface WritableConfigEntry<T> extends ConfigEntry<T> {
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Entry {
 
-    Type<T> getType();
-
-    void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException;
-
-    @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException;
-
-    default @NotNull Object getValueToWrite() throws InvalidTypeException, ValidationException {
-        return this.getValueToWrite(Function.identity());
-    }
-
-    boolean isModified();
-
-    default WritableConfigEntry<T> register(@NotNull Config config) {
-        Objects.requireNonNull(config);
-        ((ConfigImpl) config).registerEntry(this);
-        return this;
-    }
+    @NotNull String value() default "";
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/InvalidAnnotationConfigException.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/InvalidAnnotationConfigException.java
@@ -1,0 +1,32 @@
+/*
+ * JASKL - Just Another Simple Konfig Library
+ * Copyright (C) 2023 UeberallGebannt, Almighty-Satan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.github.almightysatan.jaskl.annotation;
+
+public class InvalidAnnotationConfigException extends RuntimeException {
+
+    public InvalidAnnotationConfigException(String message) {
+        super(message);
+    }
+
+    public InvalidAnnotationConfigException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/TypeHint.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/TypeHint.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
-public @interface Entry {
+public @interface TypeHint {
 
-    @NotNull String value() default "";
+    @NotNull Class<?>[] value();
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/annotation/Validate.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/annotation/Validate.java
@@ -1,0 +1,183 @@
+/*
+ * JASKL - Just Another Simple Konfig Library
+ * Copyright (C) 2023 UeberallGebannt, Almighty-Satan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.github.almightysatan.jaskl.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Contains annotations for validation
+ */
+public interface Validate {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface DoubleNotZero {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface DoubleNotPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface DoubleNotNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface DoublePositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface DoubleNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FloatNotZero {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FloatNotPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FloatNotNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FloatPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface FloatNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface IntegerNotZero {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface IntegerNotPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface IntegerNotNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface IntegerPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface IntegerNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface LongNotZero {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface LongNotPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface LongNotNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface LongPositive {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface LongNegative {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface StringNotEmpty {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface StringMinLength {
+        int value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface StringMaxLength {
+        int value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface ListNotEmpty {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface ListMinSize {
+        int value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface ListMaxSize {
+        int value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface MapNotEmpty {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface MapMinSize {
+        int value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @interface MapMaxSize {
+        int value();
+    }
+}

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -125,14 +125,14 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
 
         @Override
         public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
-            this.setField(value);
             super.setValue(value);
+            this.setField(super.getValue());
         }
 
         @Override
         public void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException {
-            this.setField(value);
             super.putValue(value);
+            this.setField(super.getValue());
         }
 
         @Override

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -48,7 +48,7 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
         this.validators.put(annotationClass, (Function) validatorFunction);
     }
 
-    public <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException {
+    public <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException, InvalidTypeException, ValidationException {
         Objects.requireNonNull(config);
         Objects.requireNonNull(configClass);
         try {
@@ -102,7 +102,8 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
         private final Object instance;
         private Object prevFieldValue;
 
-        public WritableAnnotationConfigEntry(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue, @NotNull Field field, @NotNull Object instance) {
+        public WritableAnnotationConfigEntry(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue,
+                                             @NotNull Field field, @NotNull Object instance) throws InvalidTypeException, ValidationException {
             super(type, path, description, defaultValue);
             this.field = field;
             this.instance = instance;
@@ -135,7 +136,7 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
 
         @Override
         public boolean isModified() {
-            return checkField() || super.isModified();
+            return this.checkField() || super.isModified();
         }
 
         private boolean checkField() {

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -1,0 +1,196 @@
+/*
+ * JASKL - Just Another Simple Konfig Library
+ * Copyright (C) 2023 UeberallGebannt, Almighty-Satan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.github.almightysatan.jaskl.impl;
+
+import io.github.almightysatan.jaskl.*;
+import io.github.almightysatan.jaskl.annotation.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
+
+    private final Map<Class<?>, Function<Object, Validator<Object>>> validators = new HashMap<>();
+    
+    public AnnotationConfigManagerImpl() {
+        this.registerDefaultAnnotations();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public <T> void register(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction) {
+        Objects.requireNonNull(annotationClass);
+        Objects.requireNonNull(validatorFunction);
+        this.validators.put(annotationClass, (Function) validatorFunction);
+    }
+
+    public <T> @NotNull T init(@NotNull Config config, @NotNull Class<T> configClass) throws InvalidAnnotationConfigException {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(configClass);
+        try {
+            T instance = configClass.newInstance();
+
+            for (Field field : configClass.getFields()) {
+                if (Modifier.isFinal(field.getModifiers()))
+                    throw new InvalidAnnotationConfigException(String.format("Field %s is final", field.getName()));
+
+                Entry annotation = field.getAnnotation(Entry.class);
+                if (annotation != null) {
+                    String path = annotation.value().isEmpty() ? field.getName() : annotation.value();
+                    Object defaultValue = field.get(instance);
+                    if (defaultValue == null)
+                        throw new InvalidAnnotationConfigException(String.format("Default value of field %s is null", field.getName()));
+
+                    @SuppressWarnings("unchecked")
+                    Type<Object> type = (Type<Object>) Type.of(field.getType());
+                    if (type == null)
+                        throw new InvalidAnnotationConfigException(String.format("Unknown type for field %s", field.getName()));
+
+                    Description descriptionAnnotation = field.getAnnotation(Description.class);
+                    String description = descriptionAnnotation != null ? descriptionAnnotation.value() : null;
+
+                    for (Annotation a : field.getAnnotations()) {
+                        Function<Object, Validator<Object>> validatorFunction = this.validators.get(a.annotationType());
+                        if (validatorFunction != null) {
+                            Object annotationInstance = field.getAnnotation(a.annotationType());
+                            try {
+                                type = Type.validated(type, validatorFunction.apply(annotationInstance));
+                            } catch (Throwable t) {
+                                throw new InvalidAnnotationConfigException(t);
+                            }
+                        }
+                    }
+
+                    WritableConfigEntry<?> entry = new WritableAnnotationConfigEntry<>(type, path, description, defaultValue, field, instance);
+                    entry.register(config);
+                }
+            }
+
+            return instance;
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new InvalidAnnotationConfigException(e);
+        }
+    }
+
+    private static class WritableAnnotationConfigEntry<T> extends WritableConfigEntryImpl<T> {
+
+        private final Field field;
+        private final Object instance;
+        private Object prevFieldValue;
+
+        public WritableAnnotationConfigEntry(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue, @NotNull Field field, @NotNull Object instance) {
+            super(type, path, description, defaultValue);
+            this.field = field;
+            this.instance = instance;
+            this.prevFieldValue = defaultValue;
+        }
+
+        @Override
+        public @NotNull T getValue() {
+            this.checkField();
+            return super.getValue();
+        }
+
+        @Override
+        public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
+            this.checkField();
+            return super.getValueToWrite(keyPreprocessor);
+        }
+
+        @Override
+        public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
+            this.setField(value);
+            super.setValue(value);
+        }
+
+        @Override
+        public void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException {
+            this.setField(value);
+            super.putValue(value);
+        }
+
+        @Override
+        public boolean isModified() {
+            return checkField() || super.isModified();
+        }
+
+        private boolean checkField() {
+            try {
+                @SuppressWarnings("unchecked")
+                T fieldValue = (T) this.field.get(this.instance);
+                if (this.prevFieldValue != fieldValue) {
+                    this.setValue(fieldValue);
+                    return true;
+                }
+                return false;
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private void setField(@NotNull Object value) {
+            try {
+                this.field.set(this.instance, value);
+                this.prevFieldValue = value;
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void registerDefaultAnnotations() {
+        this.register0(Validate.DoubleNotZero.class, Validator.DOUBLE_NOT_ZERO);
+        this.register0(Validate.DoubleNotPositive.class, Validator.DOUBLE_NOT_POSITIVE);
+        this.register0(Validate.DoubleNotNegative.class, Validator.DOUBLE_NOT_NEGATIVE);
+        this.register0(Validate.DoublePositive.class, Validator.DOUBLE_POSITIVE);
+        this.register0(Validate.DoubleNegative.class, Validator.DOUBLE_NEGATIVE);
+        this.register0(Validate.FloatNotZero.class, Validator.FLOAT_NOT_ZERO);
+        this.register0(Validate.FloatNotPositive.class, Validator.FLOAT_NOT_POSITIVE);
+        this.register0(Validate.FloatNotNegative.class, Validator.FLOAT_NOT_NEGATIVE);
+        this.register0(Validate.FloatPositive.class, Validator.FLOAT_POSITIVE);
+        this.register0(Validate.FloatNegative.class, Validator.FLOAT_NEGATIVE);
+        this.register0(Validate.IntegerNotZero.class, Validator.INTEGER_NOT_ZERO);
+        this.register0(Validate.IntegerNotPositive.class, Validator.INTEGER_NOT_POSITIVE);
+        this.register0(Validate.IntegerNotNegative.class, Validator.INTEGER_NOT_NEGATIVE);
+        this.register0(Validate.IntegerPositive.class, Validator.INTEGER_POSITIVE);
+        this.register0(Validate.IntegerNegative.class, Validator.INTEGER_NEGATIVE);
+        this.register0(Validate.LongNotZero.class, Validator.LONG_NOT_ZERO);
+        this.register0(Validate.LongNotPositive.class, Validator.LONG_NOT_POSITIVE);
+        this.register0(Validate.LongNotNegative.class, Validator.LONG_NOT_NEGATIVE);
+        this.register0(Validate.LongPositive.class, Validator.LONG_POSITIVE);
+        this.register0(Validate.LongNegative.class, Validator.LONG_NEGATIVE);
+        this.register0(Validate.StringNotEmpty.class, Validator.STRING_NOT_EMPTY);
+        this.register(Validate.StringMinLength.class, annotation -> Validator.stringMinLength(annotation.value()));
+        this.register(Validate.StringMaxLength.class, annotation -> Validator.stringMaxLength(annotation.value()));
+        this.register0(Validate.ListNotEmpty.class, Validator.listNotEmpty());
+        this.register(Validate.ListMinSize.class, annotation -> Validator.listMinSize(annotation.value()));
+        this.register(Validate.ListMaxSize.class, annotation -> Validator.listMaxSize(annotation.value()));
+        this.register0(Validate.MapNotEmpty.class, Validator.mapNotEmpty());
+        this.register(Validate.MapMinSize.class, annotation -> Validator.mapMinSize(annotation.value()));
+        this.register(Validate.MapMaxSize.class, annotation -> Validator.mapMaxSize(annotation.value()));
+    }
+}

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -66,7 +66,7 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
                         throw new InvalidAnnotationConfigException(String.format("Default value of field %s is null", field.getName()));
 
                     @SuppressWarnings("unchecked")
-                    Type<Object> type = (Type<Object>) Type.of(field.getType());
+                    Type<Object> type = (Type<Object>) (annotation.type().length == 0 ? Type.of(field.getType()) : Type.of(annotation.type()));
                     if (type == null)
                         throw new InvalidAnnotationConfigException(String.format("Unknown type for field %s", field.getName()));
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -42,7 +42,7 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public <T> void register(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction) {
+    public <T> void registerValidatorFunction(@NotNull Class<T> annotationClass, @NotNull Function<T, Validator<?>> validatorFunction) {
         Objects.requireNonNull(annotationClass);
         Objects.requireNonNull(validatorFunction);
         this.validators.put(annotationClass, (Function) validatorFunction);
@@ -164,34 +164,34 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
     }
 
     private void registerDefaultAnnotations() {
-        this.register0(Validate.DoubleNotZero.class, Validator.DOUBLE_NOT_ZERO);
-        this.register0(Validate.DoubleNotPositive.class, Validator.DOUBLE_NOT_POSITIVE);
-        this.register0(Validate.DoubleNotNegative.class, Validator.DOUBLE_NOT_NEGATIVE);
-        this.register0(Validate.DoublePositive.class, Validator.DOUBLE_POSITIVE);
-        this.register0(Validate.DoubleNegative.class, Validator.DOUBLE_NEGATIVE);
-        this.register0(Validate.FloatNotZero.class, Validator.FLOAT_NOT_ZERO);
-        this.register0(Validate.FloatNotPositive.class, Validator.FLOAT_NOT_POSITIVE);
-        this.register0(Validate.FloatNotNegative.class, Validator.FLOAT_NOT_NEGATIVE);
-        this.register0(Validate.FloatPositive.class, Validator.FLOAT_POSITIVE);
-        this.register0(Validate.FloatNegative.class, Validator.FLOAT_NEGATIVE);
-        this.register0(Validate.IntegerNotZero.class, Validator.INTEGER_NOT_ZERO);
-        this.register0(Validate.IntegerNotPositive.class, Validator.INTEGER_NOT_POSITIVE);
-        this.register0(Validate.IntegerNotNegative.class, Validator.INTEGER_NOT_NEGATIVE);
-        this.register0(Validate.IntegerPositive.class, Validator.INTEGER_POSITIVE);
-        this.register0(Validate.IntegerNegative.class, Validator.INTEGER_NEGATIVE);
-        this.register0(Validate.LongNotZero.class, Validator.LONG_NOT_ZERO);
-        this.register0(Validate.LongNotPositive.class, Validator.LONG_NOT_POSITIVE);
-        this.register0(Validate.LongNotNegative.class, Validator.LONG_NOT_NEGATIVE);
-        this.register0(Validate.LongPositive.class, Validator.LONG_POSITIVE);
-        this.register0(Validate.LongNegative.class, Validator.LONG_NEGATIVE);
-        this.register0(Validate.StringNotEmpty.class, Validator.STRING_NOT_EMPTY);
-        this.register(Validate.StringMinLength.class, annotation -> Validator.stringMinLength(annotation.value()));
-        this.register(Validate.StringMaxLength.class, annotation -> Validator.stringMaxLength(annotation.value()));
-        this.register0(Validate.ListNotEmpty.class, Validator.listNotEmpty());
-        this.register(Validate.ListMinSize.class, annotation -> Validator.listMinSize(annotation.value()));
-        this.register(Validate.ListMaxSize.class, annotation -> Validator.listMaxSize(annotation.value()));
-        this.register0(Validate.MapNotEmpty.class, Validator.mapNotEmpty());
-        this.register(Validate.MapMinSize.class, annotation -> Validator.mapMinSize(annotation.value()));
-        this.register(Validate.MapMaxSize.class, annotation -> Validator.mapMaxSize(annotation.value()));
+        this.registerValidator(Validate.DoubleNotZero.class, Validator.DOUBLE_NOT_ZERO);
+        this.registerValidator(Validate.DoubleNotPositive.class, Validator.DOUBLE_NOT_POSITIVE);
+        this.registerValidator(Validate.DoubleNotNegative.class, Validator.DOUBLE_NOT_NEGATIVE);
+        this.registerValidator(Validate.DoublePositive.class, Validator.DOUBLE_POSITIVE);
+        this.registerValidator(Validate.DoubleNegative.class, Validator.DOUBLE_NEGATIVE);
+        this.registerValidator(Validate.FloatNotZero.class, Validator.FLOAT_NOT_ZERO);
+        this.registerValidator(Validate.FloatNotPositive.class, Validator.FLOAT_NOT_POSITIVE);
+        this.registerValidator(Validate.FloatNotNegative.class, Validator.FLOAT_NOT_NEGATIVE);
+        this.registerValidator(Validate.FloatPositive.class, Validator.FLOAT_POSITIVE);
+        this.registerValidator(Validate.FloatNegative.class, Validator.FLOAT_NEGATIVE);
+        this.registerValidator(Validate.IntegerNotZero.class, Validator.INTEGER_NOT_ZERO);
+        this.registerValidator(Validate.IntegerNotPositive.class, Validator.INTEGER_NOT_POSITIVE);
+        this.registerValidator(Validate.IntegerNotNegative.class, Validator.INTEGER_NOT_NEGATIVE);
+        this.registerValidator(Validate.IntegerPositive.class, Validator.INTEGER_POSITIVE);
+        this.registerValidator(Validate.IntegerNegative.class, Validator.INTEGER_NEGATIVE);
+        this.registerValidator(Validate.LongNotZero.class, Validator.LONG_NOT_ZERO);
+        this.registerValidator(Validate.LongNotPositive.class, Validator.LONG_NOT_POSITIVE);
+        this.registerValidator(Validate.LongNotNegative.class, Validator.LONG_NOT_NEGATIVE);
+        this.registerValidator(Validate.LongPositive.class, Validator.LONG_POSITIVE);
+        this.registerValidator(Validate.LongNegative.class, Validator.LONG_NEGATIVE);
+        this.registerValidator(Validate.StringNotEmpty.class, Validator.STRING_NOT_EMPTY);
+        this.registerValidatorFunction(Validate.StringMinLength.class, annotation -> Validator.stringMinLength(annotation.value()));
+        this.registerValidatorFunction(Validate.StringMaxLength.class, annotation -> Validator.stringMaxLength(annotation.value()));
+        this.registerValidator(Validate.ListNotEmpty.class, Validator.listNotEmpty());
+        this.registerValidatorFunction(Validate.ListMinSize.class, annotation -> Validator.listMinSize(annotation.value()));
+        this.registerValidatorFunction(Validate.ListMaxSize.class, annotation -> Validator.listMaxSize(annotation.value()));
+        this.registerValidator(Validate.MapNotEmpty.class, Validator.mapNotEmpty());
+        this.registerValidatorFunction(Validate.MapMinSize.class, annotation -> Validator.mapMinSize(annotation.value()));
+        this.registerValidatorFunction(Validate.MapMaxSize.class, annotation -> Validator.mapMaxSize(annotation.value()));
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -65,8 +65,9 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
                     if (defaultValue == null)
                         throw new InvalidAnnotationConfigException(String.format("Default value of field %s is null", field.getName()));
 
+                    TypeHint typeHintAnnotation = field.getAnnotation(TypeHint.class);
                     @SuppressWarnings("unchecked")
-                    Type<Object> type = (Type<Object>) (annotation.type().length == 0 ? Type.of(field) : Type.of(annotation.type()));
+                    Type<Object> type = (Type<Object>) (typeHintAnnotation != null ? Type.of(typeHintAnnotation.value()) : Type.of(field));
                     if (type == null)
                         throw new InvalidAnnotationConfigException(String.format("Unknown type for field %s", field.getName()));
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationConfigManagerImpl.java
@@ -66,7 +66,7 @@ public class AnnotationConfigManagerImpl implements AnnotationConfigManager {
                         throw new InvalidAnnotationConfigException(String.format("Default value of field %s is null", field.getName()));
 
                     @SuppressWarnings("unchecked")
-                    Type<Object> type = (Type<Object>) (annotation.type().length == 0 ? Type.of(field.getType()) : Type.of(annotation.type()));
+                    Type<Object> type = (Type<Object>) (annotation.type().length == 0 ? Type.of(field) : Type.of(annotation.type()));
                     if (type == null)
                         throw new InvalidAnnotationConfigException(String.format("Unknown type for field %s", field.getName()));
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -54,7 +54,7 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
     @Override
     public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
         T parsedValue = this.toType(value);
-        if (parsedValue.equals(this.getValue()))
+        if (parsedValue.equals(this.value))
             return;
         this.value = parsedValue;
         this.modified = true;

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -35,7 +35,7 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
     private T value;
     private boolean modified = true; // true by default because Config#write should write the entry to the config if it does not exist
 
-    public WritableConfigEntryImpl(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue) {
+    public WritableConfigEntryImpl(@NotNull Type<T> type, @NotNull String path, @Nullable String description, @NotNull T defaultValue) throws InvalidTypeException, ValidationException {
         super(path, description, defaultValue);
         this.type = Objects.requireNonNull(type);
         this.value = type.toEntryType(defaultValue);

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -47,7 +47,7 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
     }
 
     @Override
-    public @NotNull T getValue() {
+    public @NotNull T getValue() throws InvalidTypeException, ValidationException {
         return this.value;
     }
 
@@ -79,7 +79,7 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
     }
 
     @Override
-    public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor)  throws InvalidTypeException {
+    public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor)  throws InvalidTypeException, ValidationException {
         try {
             return this.getType().toWritable(this.getValue(), keyPreprocessor);
         } catch (InvalidTypeException e) {

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -53,7 +53,6 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
 
     @Override
     public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
-        Objects.requireNonNull(value);
         T parsedValue = this.toType(value);
         if (parsedValue.equals(this.getValue()))
             return;
@@ -63,12 +62,13 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
 
     @Override
     public void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException {
-        Objects.requireNonNull(value);
         this.value = this.toType(value);
         this.modified = false;
     }
 
-    private T toType(@NotNull Object value) throws InvalidTypeException, ValidationException {
+    private T toType(@Nullable Object value) throws InvalidTypeException, ValidationException {
+        if (value == null)
+            throw new InvalidTypeException(this.getPath());
         try {
             return this.getType().toEntryType(value);
         } catch (InvalidTypeException e) {

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -74,7 +74,7 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
         } catch (InvalidTypeException e) {
             throw new InvalidTypeException(this.getPath(), e);
         } catch (ValidationException e) {
-            throw new ValidationException(this.getPath(), e.getErrorMessage());
+            throw new ValidationException(this.getPath(), e);
         }
     }
 

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -476,5 +476,9 @@ public class ConfigTest {
         annotationConfig1.test = "1234";
 
         Assertions.assertThrows(ValidationException.class, config1::write);
+
+        annotationConfig1.test = null;
+
+        Assertions.assertThrows(InvalidTypeException.class, config1::write);
     }
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -481,4 +481,29 @@ public class ConfigTest {
 
         Assertions.assertThrows(InvalidTypeException.class, config1::write);
     }
+
+    public static void testAnnotationMap(Supplier<Config> configSupplier) throws IOException {
+        AnnotationConfigManager annotationConfigManager = AnnotationConfigManager.create();
+
+        Config config0 = configSupplier.get();
+        ExampleAnnotationMapConfig annotationConfig0 = annotationConfigManager.init(config0, ExampleAnnotationMapConfig.class);
+
+        config0.load();
+
+        Map<Integer, String> map = new HashMap<>();
+        map.put(2, "Hello There");
+        map.put(5, "Hello World");
+
+        annotationConfig0.test = map;
+
+        config0.write();
+        config0.close();
+
+        Config config1 = configSupplier.get();
+        ExampleAnnotationMapConfig annotationConfig1 = annotationConfigManager.init(config1, ExampleAnnotationMapConfig.class);
+
+        config1.load();
+
+        Assertions.assertEquals("Hello World", annotationConfig1.test.get(5));
+    }
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -509,6 +509,6 @@ public class ConfigTest {
         config1.load();
 
         Assertions.assertEquals("Hello World", annotationConfig1.test0.get(11).get(5));
-        Assertions.assertEquals("Hello World", annotationConfig1.test1.get(11).get(5));
+        Assertions.assertEquals("Hello World", ((Map<?, ?>) annotationConfig1.test1.get(11)).get(5));
     }
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -452,8 +452,10 @@ public class ConfigTest {
     }
 
     public static void testAnnotation(Supplier<Config> configSupplier) throws IOException {
+        AnnotationConfigManager annotationConfigManager = AnnotationConfigManager.create();
+
         Config config0 = configSupplier.get();
-        ExampleAnnotationConfig annotationConfig0 = AnnotationConfigManager.register(config0, ExampleAnnotationConfig.class);
+        ExampleAnnotationConfig annotationConfig0 = annotationConfigManager.init(config0, ExampleAnnotationConfig.class);
 
         config0.load();
 
@@ -465,10 +467,14 @@ public class ConfigTest {
         config0.close();
 
         Config config1 = configSupplier.get();
-        ExampleAnnotationConfig annotationConfig1 = AnnotationConfigManager.register(config1, ExampleAnnotationConfig.class);
+        ExampleAnnotationConfig annotationConfig1 = annotationConfigManager.init(config1, ExampleAnnotationConfig.class);
 
         config1.load();
 
         Assertions.assertEquals("Hello World", annotationConfig1.test);
+
+        annotationConfig1.test = "1234";
+
+        Assertions.assertThrows(ValidationException.class, config1::write);
     }
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -21,6 +21,7 @@
 package io.github.almightysatan.jaskl.test;
 
 import io.github.almightysatan.jaskl.*;
+import io.github.almightysatan.jaskl.annotation.AnnotationConfigManager;
 import io.github.almightysatan.jaskl.entries.*;
 import org.junit.jupiter.api.Assertions;
 
@@ -448,5 +449,26 @@ public class ConfigTest {
         config1.load();
 
         Assertions.assertEquals(value, entry1.getValue());
+    }
+
+    public static void testAnnotation(Supplier<Config> configSupplier) throws IOException {
+        Config config0 = configSupplier.get();
+        ExampleAnnotationConfig annotationConfig0 = AnnotationConfigManager.register(config0, ExampleAnnotationConfig.class);
+
+        config0.load();
+
+        Assertions.assertEquals(new ExampleAnnotationConfig().test, annotationConfig0.test);
+
+        annotationConfig0.test = "Hello World";
+
+        config0.write();
+        config0.close();
+
+        Config config1 = configSupplier.get();
+        ExampleAnnotationConfig annotationConfig1 = AnnotationConfigManager.register(config1, ExampleAnnotationConfig.class);
+
+        config1.load();
+
+        Assertions.assertEquals("Hello World", annotationConfig1.test);
     }
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -459,9 +459,9 @@ public class ConfigTest {
 
         config0.load();
 
-        Assertions.assertEquals(new ExampleAnnotationConfig().test, annotationConfig0.test);
+        Assertions.assertEquals(new ExampleAnnotationConfig().annotationTestString, annotationConfig0.annotationTestString);
 
-        annotationConfig0.test = "Hello World";
+        annotationConfig0.annotationTestString = "Hello World";
 
         config0.write();
         config0.close();
@@ -471,13 +471,13 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertEquals("Hello World", annotationConfig1.test);
+        Assertions.assertEquals("Hello World", annotationConfig1.annotationTestString);
 
-        annotationConfig1.test = "1234";
+        annotationConfig1.annotationTestString = "1234";
 
         Assertions.assertThrows(ValidationException.class, config1::write);
 
-        annotationConfig1.test = null;
+        annotationConfig1.annotationTestString = null;
 
         Assertions.assertThrows(InvalidTypeException.class, config1::write);
     }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -490,11 +490,15 @@ public class ConfigTest {
 
         config0.load();
 
-        Map<Integer, String> map = new HashMap<>();
-        map.put(2, "Hello There");
-        map.put(5, "Hello World");
+        Map<Integer, String> innerMap = new HashMap<>();
+        innerMap.put(2, "Hello There");
+        innerMap.put(5, "Hello World");
 
-        annotationConfig0.test = map;
+        Map<Integer, Map<Integer, String>> outerMap = new HashMap<>();
+        outerMap.put(11, innerMap);
+
+        annotationConfig0.test0 = outerMap;
+        annotationConfig0.test1 = outerMap;
 
         config0.write();
         config0.close();
@@ -504,6 +508,7 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertEquals("Hello World", annotationConfig1.test.get(5));
+        Assertions.assertEquals("Hello World", annotationConfig1.test0.get(11).get(5));
+        Assertions.assertEquals("Hello World", annotationConfig1.test1.get(11).get(5));
     }
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationConfig.java
@@ -21,10 +21,13 @@
 package io.github.almightysatan.jaskl.test;
 
 import io.github.almightysatan.jaskl.annotation.Entry;
+import io.github.almightysatan.jaskl.annotation.Validate;
 
 public class ExampleAnnotationConfig {
 
     @Entry
+    @Validate.StringNotEmpty
+    @Validate.StringMinLength(5)
     public String test = "Default String";
 
     public ExampleAnnotationConfig() {}

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationConfig.java
@@ -28,7 +28,7 @@ public class ExampleAnnotationConfig {
     @Entry
     @Validate.StringNotEmpty
     @Validate.StringMinLength(5)
-    public String test = "Default String";
+    public String annotationTestString = "Default String";
 
     public ExampleAnnotationConfig() {}
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationConfig.java
@@ -1,0 +1,31 @@
+/*
+ * JASKL - Just Another Simple Konfig Library
+ * Copyright (C) 2023 UeberallGebannt, Almighty-Satan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package io.github.almightysatan.jaskl.test;
+
+import io.github.almightysatan.jaskl.annotation.Entry;
+
+public class ExampleAnnotationConfig {
+
+    @Entry
+    public String test = "Default String";
+
+    public ExampleAnnotationConfig() {}
+}

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
@@ -18,20 +18,17 @@
  * USA
  */
 
-package io.github.almightysatan.jaskl.annotation;
+package io.github.almightysatan.jaskl.test;
 
-import org.jetbrains.annotations.NotNull;
+import io.github.almightysatan.jaskl.annotation.Entry;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.Map;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
-public @interface Entry {
+public class ExampleAnnotationMapConfig {
 
-    @NotNull String value() default "";
+    @Entry(value = "test.annotation.map", type = {Map.class, Integer.class, String.class})
+    public Map<Integer, String> test = new HashMap<>();
 
-    @NotNull Class<?>[] type() default {};
+    public ExampleAnnotationMapConfig() {}
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
@@ -21,6 +21,7 @@
 package io.github.almightysatan.jaskl.test;
 
 import io.github.almightysatan.jaskl.annotation.Entry;
+import io.github.almightysatan.jaskl.annotation.TypeHint;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,8 +31,9 @@ public class ExampleAnnotationMapConfig {
     @Entry("test.annotation.map0")
     public Map<Integer, Map<Integer, String>> test0 = new HashMap<>();
 
-    @Entry(value = "test.annotation.map1", type = {Map.class, Integer.class, Map.class, Integer.class, String.class})
-    public Map<Integer, Map<Integer, String>> test1 = new HashMap<>();
+    @Entry(value = "test.annotation.map1")
+    @TypeHint({Map.class, Integer.class, Map.class, Integer.class, String.class})
+    public Map<?, ?> test1 = new HashMap<>();
 
     public ExampleAnnotationMapConfig() {}
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
@@ -27,8 +27,11 @@ import java.util.Map;
 
 public class ExampleAnnotationMapConfig {
 
-    @Entry(value = "test.annotation.map", type = {Map.class, Integer.class, String.class})
-    public Map<Integer, String> test = new HashMap<>();
+    @Entry("test.annotation.map0")
+    public Map<Integer, Map<Integer, String>> test0 = new HashMap<>();
+
+    @Entry(value = "test.annotation.map1", type = {Map.class, Integer.class, Map.class, Integer.class, String.class})
+    public Map<Integer, Map<Integer, String>> test1 = new HashMap<>();
 
     public ExampleAnnotationMapConfig() {}
 }

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ExampleAnnotationMapConfig.java
@@ -22,6 +22,7 @@ package io.github.almightysatan.jaskl.test;
 
 import io.github.almightysatan.jaskl.annotation.Entry;
 import io.github.almightysatan.jaskl.annotation.TypeHint;
+import io.github.almightysatan.jaskl.annotation.Validate;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,6 +34,7 @@ public class ExampleAnnotationMapConfig {
 
     @Entry(value = "test.annotation.map1")
     @TypeHint({Map.class, Integer.class, Map.class, Integer.class, String.class})
+    @Validate.MapMaxSize(1)
     public Map<?, ?> test1 = new HashMap<>();
 
     public ExampleAnnotationMapConfig() {}

--- a/hocon/src/test/java/io/github/almightysatan/jaskl/hocon/HoconConfigTest.java
+++ b/hocon/src/test/java/io/github/almightysatan/jaskl/hocon/HoconConfigTest.java
@@ -20,6 +20,7 @@
 
 package io.github.almightysatan.jaskl.hocon;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -116,5 +117,15 @@ public class HoconConfigTest {
     @Test
     public void testCustomHocon() throws IOException {
         testCustom(() -> HoconConfig.of(file2));
+    }
+
+    @Test
+    public void testAnnotationHocon() throws IOException {
+        testAnnotation(() -> HoconConfig.of(file1));
+    }
+
+    @Test
+    public void testAnnotationMapHocon() throws IOException {
+        testAnnotationMap(() -> HoconConfig.of(file1));
     }
 }

--- a/ini/src/test/java/io/github/almightysatan/jaskl/ini/IniConfigTest.java
+++ b/ini/src/test/java/io/github/almightysatan/jaskl/ini/IniConfigTest.java
@@ -105,4 +105,9 @@ public class IniConfigTest {
     public void testCustomIni() throws IOException {
         testCustom(() -> IniConfig.of(file2));
     }
+
+    @Test
+    public void testAnnotationIni() throws IOException {
+        testAnnotation(() -> IniConfig.of(file1));
+    }
 }

--- a/json/src/test/java/io/github/almightysatan/jaskl/json/JsonConfigTest.java
+++ b/json/src/test/java/io/github/almightysatan/jaskl/json/JsonConfigTest.java
@@ -20,6 +20,7 @@
 
 package io.github.almightysatan.jaskl.json;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -116,5 +117,15 @@ public class JsonConfigTest {
     @Test
     public void testCustomJson() throws IOException {
         testCustom(() -> JsonConfig.of(file2));
+    }
+
+    @Test
+    public void testAnnotationJson() throws IOException {
+        testAnnotation(() -> JsonConfig.of(file1));
+    }
+
+    @Test
+    public void testAnnotationMapJson() throws IOException {
+        testAnnotationMap(() -> JsonConfig.of(file1));
     }
 }

--- a/mongodb/src/test/java/io/github/almightysatan/jaskl/mongodb/MongodbConfigTest.java
+++ b/mongodb/src/test/java/io/github/almightysatan/jaskl/mongodb/MongodbConfigTest.java
@@ -47,6 +47,7 @@ public class MongodbConfigTest {
     private static final String COLLECTION_5 = "test5";
     private static final String COLLECTION_6 = "test6";
     private static final String COLLECTION_7 = "test7";
+    private static final String COLLECTION_8 = "test8";
 
     private static String mongoAddress;
 
@@ -162,5 +163,15 @@ public class MongodbConfigTest {
     @Test
     public void testCustomMongo() throws IOException {
         testCustom(() -> MongodbConfig.of(mongoAddress, DATABASE, COLLECTION_7));
+    }
+
+    @Test
+    public void testAnnotationMongo() throws IOException {
+        testAnnotation(() -> MongodbConfig.of(mongoAddress, DATABASE, COLLECTION_8));
+    }
+
+    @Test
+    public void testAnnotationMapMongo() throws IOException {
+        testAnnotationMap(() -> MongodbConfig.of(mongoAddress, DATABASE, COLLECTION_8));
     }
 }

--- a/properties/src/test/java/io/github/almightysatan/jaskl/properties/PropertiesConfigTest.java
+++ b/properties/src/test/java/io/github/almightysatan/jaskl/properties/PropertiesConfigTest.java
@@ -105,4 +105,9 @@ public class PropertiesConfigTest {
     public void testCustomProperties() throws IOException {
         testCustom(() -> PropertiesConfig.of(file2));
     }
+
+    @Test
+    public void testAnnotationProperties() throws IOException {
+        testAnnotation(() -> PropertiesConfig.of(file1));
+    }
 }

--- a/toml/src/test/java/io/github/almightysatan/jaskl/toml/TomlConfigTest.java
+++ b/toml/src/test/java/io/github/almightysatan/jaskl/toml/TomlConfigTest.java
@@ -20,6 +20,7 @@
 
 package io.github.almightysatan.jaskl.toml;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -116,5 +117,15 @@ public class TomlConfigTest {
     @Test
     public void testCustomToml() throws IOException {
         testCustom(() -> TomlConfig.of(file2));
+    }
+
+    @Test
+    public void testAnnotationToml() throws IOException {
+        testAnnotation(() -> TomlConfig.of(file1));
+    }
+
+    @Test
+    public void testAnnotationMapToml() throws IOException {
+        testAnnotationMap(() -> TomlConfig.of(file1));
     }
 }

--- a/yaml/src/test/java/io/github/almightysatan/jaskl/yaml/YamlConfigTest.java
+++ b/yaml/src/test/java/io/github/almightysatan/jaskl/yaml/YamlConfigTest.java
@@ -123,4 +123,10 @@ public class YamlConfigTest {
         file1.delete();
         testAnnotation(() -> YamlConfig.of(file1, "Example YAML Config"));
     }
+
+    @Test
+    public void testAnnotationMapYaml() throws IOException {
+        file1.delete();
+        testAnnotationMap(() -> YamlConfig.of(file1, "Example YAML Config"));
+    }
 }

--- a/yaml/src/test/java/io/github/almightysatan/jaskl/yaml/YamlConfigTest.java
+++ b/yaml/src/test/java/io/github/almightysatan/jaskl/yaml/YamlConfigTest.java
@@ -117,4 +117,10 @@ public class YamlConfigTest {
     public void testCustomYaml() throws IOException {
         testCustom(() -> YamlConfig.of(file2, "Example YAML Config"));
     }
+
+    @Test
+    public void testAnnotationYaml() throws IOException {
+        file1.delete();
+        testAnnotation(() -> YamlConfig.of(file1, "Example YAML Config"));
+    }
 }

--- a/yaml/src/test/java/io/github/almightysatan/jaskl/yaml/YamlConfigTest.java
+++ b/yaml/src/test/java/io/github/almightysatan/jaskl/yaml/YamlConfigTest.java
@@ -120,13 +120,11 @@ public class YamlConfigTest {
 
     @Test
     public void testAnnotationYaml() throws IOException {
-        file1.delete();
         testAnnotation(() -> YamlConfig.of(file1, "Example YAML Config"));
     }
 
     @Test
     public void testAnnotationMapYaml() throws IOException {
-        file1.delete();
         testAnnotationMap(() -> YamlConfig.of(file1, "Example YAML Config"));
     }
 }


### PR DESCRIPTION
Example:
```java
public class ExampleAnnotationConfig {

    @Entry
    @Validate.StringNotEmpty
    public String myString = "Default String"; // Default values should not be null

    @Entry("some.other.path")
    @Description("Enter description here") // May be ignored if the implementation does not support comments
    public int myInt = 5;

    public ExampleAnnotationConfig() {} // An empty constructor is required
}
```
```java
AnnotationConfigManager annotationConfigManager = AnnotationConfigManager.create(); // Create an AnnotationConfigManager. The instance can be reused.

Config yamlConfig = YamlConfig.of(file); // Create a config

// Register our annotated class
ExampleAnnotationConfig config = annotationConfigManager.init(yamlConfig, ExampleAnnotationConfig.class);

yamlConfig.load(); // Load the config from storage

System.out.println(config.myString); // Print some value we just loaded

config.myString = "Hello World"; // Change the value

// Write the config to storage
// This also checks/validates changed values
yamlConfig.write();
```