### PR TITLE
Rename api methods to match SLAMS

### DIFF
--- a/core/src/main/java/io/github/almightysatan/jaskl/Config.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/Config.java
@@ -75,5 +75,5 @@ public interface Config {
      *
      * @return the description of this config
      */
-    @Nullable String getDescription();
+    @Nullable String description();
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/ConfigEntry.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/ConfigEntry.java
@@ -31,14 +31,14 @@ public interface ConfigEntry<T> {
      *
      * @return the path of this ConfigEntry
      */
-    @NotNull String getPath();
+    @NotNull String path();
 
     /**
      * Returns the description of this ConfigEntry.
      *
      * @return the description of this ConfigEntry
      */
-    @Nullable String getDescription();
+    @Nullable String description();
 
     /**
      * Returns the value of this ConfigEntry.
@@ -47,14 +47,14 @@ public interface ConfigEntry<T> {
      * @throws InvalidTypeException if the value does not match its expected {@link Type}
      * @throws ValidationException  if the value fails validation
      */
-    @NotNull T getValue() throws InvalidTypeException, ValidationException;
+    @NotNull T value() throws InvalidTypeException, ValidationException;
 
     /**
      * Returns the value of this ConfigEntry.
      *
      * @return the value of this ConfigEntry
      */
-    @NotNull T getDefaultValue();
+    @NotNull T defaultValue();
 
     /**
      * Updates the value of this ConfigEntry.

--- a/core/src/main/java/io/github/almightysatan/jaskl/ValidationException.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/ValidationException.java
@@ -54,7 +54,7 @@ public class ValidationException extends RuntimeException {
      *
      * @return The path of the config entry
      */
-    public @Nullable String getPath() {
+    public @Nullable String path() {
         return this.path;
     }
 
@@ -63,7 +63,7 @@ public class ValidationException extends RuntimeException {
      *
      * @return The error message
      */
-    public @NotNull String getErrorMessage() {
+    public @NotNull String errorMessage() {
         return this.errorMessage;
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationManagerImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/AnnotationManagerImpl.java
@@ -85,27 +85,27 @@ public class AnnotationManagerImpl implements AnnotationManager {
         }
 
         @Override
-        public @NotNull T getValue() {
+        public @NotNull T value() {
             this.checkField();
-            return super.getValue();
+            return super.value();
         }
 
         @Override
-        public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
+        public @NotNull Object valueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
             this.checkField();
-            return super.getValueToWrite(keyPreprocessor);
+            return super.valueToWrite(keyPreprocessor);
         }
 
         @Override
         public void setValue(@NotNull T value) throws InvalidTypeException, ValidationException {
             super.setValue(value);
-            this.setField(super.getValue());
+            this.setField(super.value());
         }
 
         @Override
         public void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException {
             super.putValue(value);
-            this.setField(super.getValue());
+            this.setField(super.value());
         }
 
         @Override

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/ConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/ConfigEntryImpl.java
@@ -67,17 +67,17 @@ public abstract class ConfigEntryImpl<T> implements ConfigEntry<T> {
     }
 
     @Override
-    public @NotNull String getPath() {
+    public @NotNull String path() {
         return this.path;
     }
 
     @Override
-    public @Nullable String getDescription() {
+    public @Nullable String description() {
         return this.description;
     }
 
     @Override
-    public @NotNull T getDefaultValue() {
+    public @NotNull T defaultValue() {
         return this.defaultValue;
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/ConfigImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/ConfigImpl.java
@@ -39,20 +39,20 @@ public abstract class ConfigImpl implements Config {
     public void registerEntry(@NotNull ConfigEntry<?> entry) {
         Objects.requireNonNull(entry);
 
-        String entryPathDot = entry.getPath() + ".";
-        for (String path : this.getPaths()) {
-            if (path.equals(entry.getPath()))
-                throw new IllegalArgumentException(String.format("Duplicate path %s", entry.getPath()));
+        String entryPathDot = entry.path() + ".";
+        for (String path : this.paths()) {
+            if (path.equals(entry.path()))
+                throw new IllegalArgumentException(String.format("Duplicate path %s", entry.path()));
 
-            if (path.startsWith(entryPathDot) || entry.getPath().startsWith(path + "."))
-                throw new IllegalArgumentException(String.format("Paths have to be prefix-free! %s", entry.getPath()));
+            if (path.startsWith(entryPathDot) || entry.path().startsWith(path + "."))
+                throw new IllegalArgumentException(String.format("Paths have to be prefix-free! %s", entry.path()));
         }
 
-        this.entries.put(entry.getPath(), entry);
+        this.entries.put(entry.path(), entry);
     }
 
     @Override
-    public @Nullable String getDescription() {
+    public @Nullable String description() {
         return description;
     }
 
@@ -61,7 +61,7 @@ public abstract class ConfigImpl implements Config {
      *
      * @return a map of all paths with their config entries
      */
-    public @NotNull Map<String, ConfigEntry<?>> getEntries() {
+    public @NotNull Map<String, ConfigEntry<?>> entries() {
         return entries;
     }
 
@@ -70,8 +70,8 @@ public abstract class ConfigImpl implements Config {
      *
      * @return a set of all the paths of the config entries
      */
-    public @NotNull Set<String> getPaths() {
-        return this.getEntries().keySet();
+    public @NotNull Set<String> paths() {
+        return this.entries().keySet();
     }
 
     /**
@@ -79,12 +79,12 @@ public abstract class ConfigImpl implements Config {
      *
      * @return a collection of all config entries
      */
-    public @NotNull Collection<ConfigEntry<?>> getValues() {
-        return this.getEntries().values();
+    public @NotNull Collection<ConfigEntry<?>> values() {
+        return this.entries().values();
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected @NotNull Collection<WritableConfigEntry<?>> getCastedValues() {
-        return (Collection<WritableConfigEntry<?>>) (Collection) getEntries().values();
+    protected @NotNull Collection<WritableConfigEntry<?>> castedValues() {
+        return (Collection<WritableConfigEntry<?>>) (Collection) entries().values();
     }
 }

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntry.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntry.java
@@ -28,14 +28,14 @@ import java.util.function.Function;
 
 public interface WritableConfigEntry<T> extends ConfigEntry<T> {
 
-    @NotNull Type<T> getType();
+    @NotNull Type<T> type();
 
     void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException;
 
-    @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException;
+    @NotNull Object valueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException;
 
-    default @NotNull Object getValueToWrite() throws InvalidTypeException, ValidationException {
-        return this.getValueToWrite(Function.identity());
+    default @NotNull Object valueToWrite() throws InvalidTypeException, ValidationException {
+        return this.valueToWrite(Function.identity());
     }
 
     boolean isModified();

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -42,12 +42,12 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
     }
 
     @Override
-    public @NotNull Type<T> getType() {
+    public @NotNull Type<T> type() {
         return this.type;
     }
 
     @Override
-    public @NotNull T getValue() throws InvalidTypeException, ValidationException {
+    public @NotNull T value() throws InvalidTypeException, ValidationException {
         return this.value;
     }
 
@@ -68,22 +68,22 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
 
     private @NotNull T toType(@Nullable Object value) throws InvalidTypeException, ValidationException {
         if (value == null)
-            throw new InvalidTypeException(this.getPath());
+            throw new InvalidTypeException(this.path());
         try {
-            return this.getType().toEntryType(value);
+            return this.type().toEntryType(value);
         } catch (InvalidTypeException e) {
-            throw new InvalidTypeException(this.getPath(), e);
+            throw new InvalidTypeException(this.path(), e);
         } catch (ValidationException e) {
-            throw new ValidationException(this.getPath(), e);
+            throw new ValidationException(this.path(), e);
         }
     }
 
     @Override
-    public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
+    public @NotNull Object valueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
         try {
-            return this.getType().toWritable(this.getValue(), keyPreprocessor);
+            return this.type().toWritable(this.value(), keyPreprocessor);
         } catch (InvalidTypeException e) {
-            throw new InvalidTypeException(this.getPath(), e);
+            throw new InvalidTypeException(this.path(), e);
         }
     }
 

--- a/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
+++ b/core/src/testFixtures/java/io/github/almightysatan/jaskl/test/ConfigTest.java
@@ -96,13 +96,13 @@ public class ConfigTest {
 
         config.load();
 
-        Assertions.assertEquals(true, booleanConfigEntry.getValue());
-        Assertions.assertEquals(1.0D, doubleConfigEntry.getValue());
-        Assertions.assertEquals(1.0F, floatConfigEntry.getValue());
-        Assertions.assertEquals(1, integerConfigEntry.getValue());
-        Assertions.assertEquals(1L, longConfigEntry.getValue());
-        Assertions.assertEquals("modified", stringConfigEntry.getValue());
-        Assertions.assertEquals("spe-ci_al", specialCharEntry.getValue());
+        Assertions.assertEquals(true, booleanConfigEntry.value());
+        Assertions.assertEquals(1.0D, doubleConfigEntry.value());
+        Assertions.assertEquals(1.0F, floatConfigEntry.value());
+        Assertions.assertEquals(1, integerConfigEntry.value());
+        Assertions.assertEquals(1L, longConfigEntry.value());
+        Assertions.assertEquals("modified", stringConfigEntry.value());
+        Assertions.assertEquals("spe-ci_al", specialCharEntry.value());
 
         config.close();
     }
@@ -137,7 +137,7 @@ public class ConfigTest {
 
         config.load();
 
-        Assertions.assertEquals(ExampleEnum.ANOTHER_EXAMPLE, enumConfigEntry.getValue());
+        Assertions.assertEquals(ExampleEnum.ANOTHER_EXAMPLE, enumConfigEntry.value());
 
         config.close();
     }
@@ -155,7 +155,7 @@ public class ConfigTest {
         config.load();
 
         List<String> example1 = Arrays.asList("Example3", "Example4");
-        Assertions.assertEquals(example1, listConfigEntry.getValue());
+        Assertions.assertEquals(example1, listConfigEntry.value());
 
         config.close();
     }
@@ -178,7 +178,7 @@ public class ConfigTest {
         example1.put("Hello", "there");
         example1.put("abc", "xyz");
         example1.put("x", "y");
-        Assertions.assertEquals(example1, mapConfigEntry.getValue());
+        Assertions.assertEquals(example1, mapConfigEntry.value());
 
         config.close();
     }
@@ -212,8 +212,8 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertEquals("modified", stringConfigEntry1.getValue());
-        Assertions.assertEquals(1, intConfigEntry1.getValue());
+        Assertions.assertEquals("modified", stringConfigEntry1.value());
+        Assertions.assertEquals(1, intConfigEntry1.value());
 
         config1.close();
     }
@@ -240,8 +240,8 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertEquals(bigDecimalConfigEntry0.getValue(), bigDecimalConfigEntry1.getValue());
-        Assertions.assertEquals(bigIntegerConfigEntry0.getValue(), bigIntegerConfigEntry1.getValue());
+        Assertions.assertEquals(bigDecimalConfigEntry0.value(), bigDecimalConfigEntry1.value());
+        Assertions.assertEquals(bigIntegerConfigEntry0.value(), bigIntegerConfigEntry1.value());
     }
 
     /**
@@ -272,7 +272,7 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertArrayEquals(list1.toArray(new Double[0]), listConfigEntry1.getValue().toArray(new Double[0]));
+        Assertions.assertArrayEquals(list1.toArray(new Double[0]), listConfigEntry1.value().toArray(new Double[0]));
 
         config1.close();
     }
@@ -306,7 +306,7 @@ public class ConfigTest {
         config1.load();
 
         Assertions.assertArrayEquals(list1.stream().map(list -> list.toArray(new Integer[0])).toArray(Integer[][]::new),
-                listConfigEntry1.getValue().stream().map(list -> list.toArray(new Integer[0])).toArray(Integer[][]::new));
+                listConfigEntry1.value().stream().map(list -> list.toArray(new Integer[0])).toArray(Integer[][]::new));
 
         config1.close();
     }
@@ -339,7 +339,7 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertArrayEquals(list1.toArray(new ExampleEnum[0]), listConfigEntry1.getValue().toArray(new ExampleEnum[0]));
+        Assertions.assertArrayEquals(list1.toArray(new ExampleEnum[0]), listConfigEntry1.value().toArray(new ExampleEnum[0]));
 
         config1.close();
     }
@@ -376,7 +376,7 @@ public class ConfigTest {
 
         config1.load();
 
-        Assertions.assertEquals(map1, mapConfigEntry1.getValue());
+        Assertions.assertEquals(map1, mapConfigEntry1.value());
 
         config1.close();
     }
@@ -413,8 +413,8 @@ public class ConfigTest {
 
         config2.load();
 
-        Assertions.assertEquals("modified", stringConfigEntry2.getValue());
-        Assertions.assertEquals(0, intConfigEntry2.getValue());
+        Assertions.assertEquals("modified", stringConfigEntry2.value());
+        Assertions.assertEquals(0, intConfigEntry2.value());
 
         config2.close();
     }
@@ -463,8 +463,8 @@ public class ConfigTest {
 
         config2.load();
 
-        Assertions.assertEquals(map0New, mapConfigEntry0New.getValue());
-        Assertions.assertEquals(map1, mapConfigEntry1New.getValue());
+        Assertions.assertEquals(map0New, mapConfigEntry0New.value());
+        Assertions.assertEquals(map1, mapConfigEntry1New.value());
 
         config2.close();
     }
@@ -492,8 +492,8 @@ public class ConfigTest {
         config1.load();
         config1.close();
 
-        Assertions.assertEquals(value, entry2.getValue());
-        Assertions.assertEquals(nestedValue, entry3.getValue());
+        Assertions.assertEquals(value, entry2.value());
+        Assertions.assertEquals(nestedValue, entry3.value());
     }
 
     public static void testAnnotation(Supplier<Config> configSupplier) throws IOException {

--- a/hocon/src/main/java/io/github/almightysatan/jaskl/hocon/HoconConfig.java
+++ b/hocon/src/main/java/io/github/almightysatan/jaskl/hocon/HoconConfig.java
@@ -68,10 +68,10 @@ public class HoconConfig extends ConfigImpl {
     public void reload() throws IllegalStateException {
         if (this.config == null)
             throw new IllegalStateException();
-        for (ConfigEntry<?> uncastedConfigEntry : this.getValues()) {
+        for (ConfigEntry<?> uncastedConfigEntry : this.values()) {
             WritableConfigEntry<?> configEntry = (WritableConfigEntry<?>) uncastedConfigEntry;
             try {
-                Object value = this.config.getValue(configEntry.getPath()).unwrapped();
+                Object value = this.config.getValue(configEntry.path()).unwrapped();
                 configEntry.putValue(value);
             } catch (ConfigException.Missing ignored) {
             }
@@ -85,17 +85,17 @@ public class HoconConfig extends ConfigImpl {
             throw new IllegalStateException();
         Util.createFileAndPath(this.file);
 
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
             if (configEntry.isModified()) {
-                Object entryValue = configEntry.getValueToWrite(Object::toString);
+                Object entryValue = configEntry.valueToWrite(Object::toString);
                 if (entryValue instanceof BigInteger)
                     entryValue = entryValue.toString();
                 if (entryValue instanceof BigDecimal)
                     entryValue = entryValue.toString();
                 ConfigValue value = ConfigValueFactory.fromAnyRef(entryValue);
-                if (configEntry.getDescription() != null)
-                    value = value.withOrigin(value.origin().withComments(Collections.singletonList(configEntry.getDescription())));
-                config = config.withValue(configEntry.getPath(), value);
+                if (configEntry.description() != null)
+                    value = value.withOrigin(value.origin().withComments(Collections.singletonList(configEntry.description())));
+                config = config.withValue(configEntry.path(), value);
             }
         }
 
@@ -110,7 +110,7 @@ public class HoconConfig extends ConfigImpl {
         Util.createFileAndPath(this.file);
 
         List<String> pathsToRemove = new ArrayList<>();
-        this.resolvePathsToStrip("", config.root(), this.getPaths(), pathsToRemove);
+        this.resolvePathsToStrip("", config.root(), this.paths(), pathsToRemove);
         for (String path : pathsToRemove)
             config = config.withoutPath(path);
 
@@ -125,7 +125,7 @@ public class HoconConfig extends ConfigImpl {
 
     protected void writeIfNecessary(@NotNull Config config, boolean setDescription) throws IOException {
         if (config != this.config) {
-            ConfigObject root = setDescription ? config.root().withOrigin(this.config.root().origin().withComments(this.getDescription() == null ? null : Collections.singletonList(this.getDescription()))) : config.root();
+            ConfigObject root = setDescription ? config.root().withOrigin(this.config.root().origin().withComments(this.description() == null ? null : Collections.singletonList(this.description()))) : config.root();
             String output = root.render(RENDER_OPTIONS);
             try (FileWriter fileWriter = new FileWriter(this.file)) {
                 fileWriter.write(output);

--- a/jackson/src/main/java/io/github/almightysatan/jaskl/jackson/JacksonConfigImpl.java
+++ b/jackson/src/main/java/io/github/almightysatan/jaskl/jackson/JacksonConfigImpl.java
@@ -73,8 +73,8 @@ public abstract class JacksonConfigImpl extends ConfigImpl {
             throw new IOException(e);
         }
 
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
-            JsonNode node = this.resolveNode(configEntry.getPath());
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
+            JsonNode node = this.resolveNode(configEntry.path());
             if (node == null)
                 continue;
 
@@ -90,9 +90,9 @@ public abstract class JacksonConfigImpl extends ConfigImpl {
         Util.createFileAndPath(this.file);
 
         boolean shouldWrite = false;
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
             if (configEntry.isModified()) {
-                this.putNode(configEntry.getPath(), this.mapper.valueToTree(configEntry.getValueToWrite()));
+                this.putNode(configEntry.path(), this.mapper.valueToTree(configEntry.valueToWrite()));
                 shouldWrite = true;
             }
         }
@@ -107,7 +107,7 @@ public abstract class JacksonConfigImpl extends ConfigImpl {
             throw new IllegalStateException();
         Util.createFileAndPath(this.file);
 
-        if (stripNodes("", this.root, this.getPaths()))
+        if (stripNodes("", this.root, this.paths()))
             this.mapper.writerWithDefaultPrettyPrinter().writeValue(this.file, this.root);
     }
 

--- a/mongodb/src/main/java/io/github/almightysatan/jaskl/mongodb/MongodbConfig.java
+++ b/mongodb/src/main/java/io/github/almightysatan/jaskl/mongodb/MongodbConfig.java
@@ -79,8 +79,8 @@ public class MongodbConfig extends ConfigImpl {
             throw new IOException(e);
         }
 
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
-            Document document = entries.get(configEntry.getPath());
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
+            Document document = entries.get(configEntry.path());
 
             if (document != null) {
                 Object value = document.get("value");
@@ -96,10 +96,10 @@ public class MongodbConfig extends ConfigImpl {
             throw new IllegalStateException();
 
         List<WriteModel<? extends Document>> writeModels = new ArrayList<>();
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues())
+        for (WritableConfigEntry<?> configEntry : this.castedValues())
             if (configEntry.isModified()) {
                 Document document = new Document();
-                Object value = configEntry.getValueToWrite(Object::toString);
+                Object value = configEntry.valueToWrite(Object::toString);
                 if (value instanceof BigInteger)
                     value = value.toString();
                 if (value instanceof BigDecimal)
@@ -109,7 +109,7 @@ public class MongodbConfig extends ConfigImpl {
                 Document updateDocument = new Document();
                 updateDocument.put("$set", document);
 
-                writeModels.add(new UpdateOneModel<>(Filters.eq("_id", configEntry.getPath()), updateDocument, UPDATE_OPTIONS));
+                writeModels.add(new UpdateOneModel<>(Filters.eq("_id", configEntry.path()), updateDocument, UPDATE_OPTIONS));
             }
         if (!writeModels.isEmpty())
             try {
@@ -125,7 +125,7 @@ public class MongodbConfig extends ConfigImpl {
             throw new IllegalStateException();
 
         try {
-            Set<String> paths = this.getPaths();
+            Set<String> paths = this.paths();
             List<WriteModel<? extends Document>> writeModels = new ArrayList<>();
             FindIterable<Document> documents = this.mongoCollection.find();
             for (Document document : documents) {

--- a/properties/src/main/java/io/github/almightysatan/jaskl/properties/PropertiesConfig.java
+++ b/properties/src/main/java/io/github/almightysatan/jaskl/properties/PropertiesConfig.java
@@ -75,9 +75,9 @@ public class PropertiesConfig extends ConfigImpl {
         Util.createFileAndPath(this.file);
 
         boolean shouldWrite = false;
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
             if (configEntry.isModified()) {
-                this.config.setProperty(configEntry.getPath(), configEntry.getValueToWrite().toString());
+                this.config.setProperty(configEntry.path(), configEntry.valueToWrite().toString());
                 shouldWrite = true;
             }
         }
@@ -94,7 +94,7 @@ public class PropertiesConfig extends ConfigImpl {
 
         boolean shouldWrite = false;
         Properties stripped = new Properties();
-        Set<String> paths = this.getPaths();
+        Set<String> paths = this.paths();
         for (Entry<Object, Object> entry : this.config.entrySet()) {
             String key = (String) entry.getKey();
             if (!paths.contains(key)) {
@@ -123,7 +123,7 @@ public class PropertiesConfig extends ConfigImpl {
      */
     private void writeToFile() throws IOException {
         try (FileWriter writer = new FileWriter(file)) {
-            this.config.store(writer, this.getDescription());
+            this.config.store(writer, this.description());
         }
     }
 
@@ -142,10 +142,10 @@ public class PropertiesConfig extends ConfigImpl {
      * Initializes all config entries by setting the value based on the property instance
      */
     private void populateEntries() {
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
             if (configEntry instanceof ListConfigEntry || configEntry instanceof MapConfigEntry)
                 throw new UnsupportedOperationException("Lists are not supported in Property Configs.");
-            Object value = this.config.get(configEntry.getPath());
+            Object value = this.config.get(configEntry.path());
             if (value != null)
                 configEntry.putValue(value);
         }

--- a/yaml/src/main/java/io/github/almightysatan/jaskl/yaml/YamlConfig.java
+++ b/yaml/src/main/java/io/github/almightysatan/jaskl/yaml/YamlConfig.java
@@ -91,10 +91,10 @@ public class YamlConfig extends ConfigImpl {
             throw new IllegalStateException();
         Util.createFileAndPath(this.file);
 
-        this.setComment(this.root, this.getDescription());
+        this.setComment(this.root, this.description());
 
         boolean shouldWrite = false;
-        for (WritableConfigEntry<?> configEntry : this.getCastedValues()) {
+        for (WritableConfigEntry<?> configEntry : this.castedValues()) {
             if (configEntry.isModified()) {
                 this.putNode(configEntry);
                 shouldWrite = true;
@@ -113,7 +113,7 @@ public class YamlConfig extends ConfigImpl {
             throw new IllegalStateException();
         Util.createFileAndPath(this.file);
 
-        if (this.stripNodes("", this.root, this.getPaths()))
+        if (this.stripNodes("", this.root, this.paths()))
             try (FileWriter fileWriter = new FileWriter(this.file)) {
                 this.yaml.serialize(this.root, fileWriter);
             }
@@ -149,7 +149,7 @@ public class YamlConfig extends ConfigImpl {
      * @return true if the entry exists
      */
     protected boolean loadValueIfEntryExists(String path, Node node) {
-        WritableConfigEntry<?> entry = (WritableConfigEntry<?>) this.getEntries().get(path);
+        WritableConfigEntry<?> entry = (WritableConfigEntry<?>) this.entries().get(path);
         if (entry == null)
             return false;
         Object value = CONSTRUCTOR.constructObject(node);
@@ -159,7 +159,7 @@ public class YamlConfig extends ConfigImpl {
     }
 
     protected void putNode(@NotNull WritableConfigEntry<?> entry) {
-        String[] pathSplit = entry.getPath().split("\\.");
+        String[] pathSplit = entry.path().split("\\.");
         MappingNode node = this.root;
         pathLoop: for (int i = 0; i < pathSplit.length; i++) {
             for (NodeTuple tuple : node.getValue()) {
@@ -172,7 +172,7 @@ public class YamlConfig extends ConfigImpl {
                         node.getValue().replaceAll(nodeTuple -> {
                             if (nodeTuple != tuple)
                                 return nodeTuple;
-                            return this.newNodeTuple(pathSplit[pathSplit.length - 1], entry.getDescription(), entry.getValueToWrite());
+                            return this.newNodeTuple(pathSplit[pathSplit.length - 1], entry.description(), entry.valueToWrite());
                         });
                         return;
                     }
@@ -185,7 +185,7 @@ public class YamlConfig extends ConfigImpl {
                 node.getValue().add(new NodeTuple(this.yaml.represent(pathSplit[i]), newNode));
                 node = newNode;
             } else {
-                node.getValue().add(this.newNodeTuple(pathSplit[pathSplit.length - 1], entry.getDescription(), entry.getValueToWrite()));
+                node.getValue().add(this.newNodeTuple(pathSplit[pathSplit.length - 1], entry.description(), entry.valueToWrite()));
                 return;
             }
         }


### PR DESCRIPTION
- Renamed all API methods to fit their SLAMS "counterpart"
- `getFoo()` --> `foo()`


This currently has breaking changes, I might deprecate the old methods and link them to the new ones.