### PR TITLE
Fix modified flag

### DIFF
--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntry.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntry.java
@@ -32,9 +32,22 @@ public interface WritableConfigEntry<T> extends ConfigEntry<T> {
 
     void putValue(@NotNull Object value) throws InvalidTypeException, ValidationException;
 
-    @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException;
+    /**
+     * Returns the value that should be written to a persistent config. This also sets modified to false.
+     *
+     * @param keyPreprocessor a {@link Function} that will be invoked on all map keys
+     * @return a value that can be written to a config
+     * @throws InvalidTypeException if the type of this ConfigEntry's value is incorrect. This shouldn't happen under normal circumstances.
+     */
+    @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException;
 
-    default @NotNull Object getValueToWrite() throws InvalidTypeException, ValidationException {
+    /**
+     * Returns the value that should be written to a persistent config. This also sets modified to false.
+     *
+     * @return a value that can be written to a config
+     * @throws InvalidTypeException if the type of this ConfigEntry's value is incorrect. This shouldn't happen under normal circumstances.
+     */
+    default @NotNull Object getValueToWrite() throws InvalidTypeException {
         return this.getValueToWrite(Function.identity());
     }
 

--- a/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
+++ b/core/src/main/java/io/github/almightysatan/jaskl/impl/WritableConfigEntryImpl.java
@@ -79,9 +79,11 @@ public class WritableConfigEntryImpl<T> extends ConfigEntryImpl<T> implements Wr
     }
 
     @Override
-    public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException, ValidationException {
+    public @NotNull Object getValueToWrite(@NotNull Function<@NotNull Object, @NotNull Object> keyPreprocessor) throws InvalidTypeException {
         try {
-            return this.getType().toWritable(this.getValue(), keyPreprocessor);
+            Object o = this.getType().toWritable(this.getValue(), keyPreprocessor);
+            this.modified = false;
+            return o;
         } catch (InvalidTypeException e) {
             throw new InvalidTypeException(this.getPath(), e);
         }


### PR DESCRIPTION
Sets `modified` to false when writing the config to prevent unnecessary write operations when calling `Config#write` multiple times. Also `WritableConfigEntry#getValueToWrite` doesn't actually throw a `ValidationException` as values are validated when calling `#setValue`.
Maybe `#getValueToWrite` should be renamed to something more descriptive.